### PR TITLE
Add CI test to confirm empty inventory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ script:
 - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then $TRAVIS_BUILD_DIR/ci/script_run_on_non_pull_requests.sh;
   fi
 - $TRAVIS_BUILD_DIR/ci/confirm_empty_inventory.sh;
-- pushd $TRAVIS_BUILD_DIR && ansible-lint -x ANSIBLE0004,ANSIBLE0010,ANSIBLE0012 --exclude=ansible/roles/mikegleasonjr.firewall
-  --exclude=ansible/roles/geerlingguy.nginx ansible/site.yml && popd
+- $TRAVIS_BUILD_DIR/ci/run_ansible_lint.sh;
 after_script:
 - pushd $TRAVIS_BUILD_DIR/ci && vagrant destroy -f && popd
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
   fi
 - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then $TRAVIS_BUILD_DIR/ci/script_run_on_non_pull_requests.sh;
   fi
+- $TRAVIS_BUILD_DIR/ci/confirm_empty_inventory.sh;
 - pushd $TRAVIS_BUILD_DIR && ansible-lint -x ANSIBLE0004,ANSIBLE0010,ANSIBLE0012 --exclude=ansible/roles/mikegleasonjr.firewall
   --exclude=ansible/roles/geerlingguy.nginx ansible/site.yml && popd
 after_script:

--- a/ansible/inventory
+++ b/ansible/inventory
@@ -1,1 +1,3 @@
+# Example entry. Replace the IP address with the address of your pi
+#
 #192.168.20.183 ansible_user=pi

--- a/ci/confirm_empty_inventory.sh
+++ b/ci/confirm_empty_inventory.sh
@@ -9,7 +9,7 @@
 
 echo "Confirming inventory file only contains comments."
 count=$(grep -c -v "^#" ansible/inventory);
-if [[ $count -gt 0 ]]; then
+if [ $count -gt 0 ]; then
     echo "FAIL: Inventory file contains ${count} non-comment lines";
     exit 1;
 else

--- a/ci/confirm_empty_inventory.sh
+++ b/ci/confirm_empty_inventory.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# The inventory file is used by lots of people, and when populated, contains
+#  info that is only relevant to a specific person. We make sure that it only
+#  contains comments/template for others to follow, but no actual entries.
+#
+# Assumes it will be run in the root of the checkout i.e. at the same level
+#  as .travis.yml
+
+echo "Confirming inventory file only contains comments."
+count=$(grep -c -v "^#" ansible/inventory);
+if [[ $count -gt 0 ]]; then
+    echo "FAIL: Inventory file contains ${count} non-comment lines";
+    exit 1;
+else
+    echo "PASS: Inventory only contains comment lines";
+    exit 0;
+fi

--- a/ci/run_ansible_lint.sh
+++ b/ci/run_ansible_lint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Run ansible lint over non-third party modules
+#
+# Assumes it will be run from the root directory of the checkout i.e.
+#  the same directory as .travis.yml
+
+ansible-lint \
+	-x ANSIBLE0004,ANSIBLE0010,ANSIBLE0012 \
+	--exclude=ansible/roles/mikegleasonjr.firewall \
+	--exclude=ansible/roles/geerlingguy.nginx \
+	ansible/site.yml


### PR DESCRIPTION
It's too easy to accidentally commit an inventory that has a server listed, so write a test to prevent it (and remove my inventory entry). Also confirm the ansible-lint step into its own ci script instead of a raw command.