### PR TITLE
Initial site tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .vagrant
 *.pem
 ci/inventory
+ghostdriver.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: required
 dist: trusty
 before_install:
 - sudo apt-get -qq update
+- "phantomjs --version"
 install:
 - wget -O /tmp/vagrant.deb https://releases.hashicorp.com/vagrant/1.8.7/vagrant_1.8.7_x86_64.deb
 - sudo dpkg -i /tmp/vagrant.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: bash
+language: python
 sudo: required
 dist: trusty
 before_install:

--- a/ci/script_run_on_non_pull_requests.sh
+++ b/ci/script_run_on_non_pull_requests.sh
@@ -41,6 +41,6 @@ vagrant provision
 # Run selenium tests
 
 # Tell the test running host how to find the biblebox by name
-echo "${TEST_IP} biblebox.local" | sudo tee -a /etc/hosts > /dev/null
+echo "\n${target_host} biblebox.local" | sudo tee -a /etc/hosts > /dev/null
 cat /etc/hosts
 TEST_IP=$target_host nose2

--- a/ci/script_run_on_non_pull_requests.sh
+++ b/ci/script_run_on_non_pull_requests.sh
@@ -38,9 +38,8 @@ vagrant provision
 #  without marking any task as changed
 vagrant provision
 
-# Run selenium tests
 
 # Tell the test running host how to find the biblebox by name
 echo "\n$(dig +short ${target_host}) biblebox.local" | sudo tee -a /etc/hosts > /dev/null
-cat /etc/hosts
+# Run web/selenium tests
 TEST_IP=$target_host nose2

--- a/ci/script_run_on_non_pull_requests.sh
+++ b/ci/script_run_on_non_pull_requests.sh
@@ -37,3 +37,10 @@ vagrant provision
 # Perform a re-run of the playbooks, to see whether they run cleanly and
 #  without marking any task as changed
 vagrant provision
+
+# Run selenium tests
+
+# Tell the test running host how to find the biblebox by name
+echo "${TEST_IP} biblebox.local" | sudo tee -a /etc/hosts > /dev/null
+cat /etc/hosts
+TEST_IP=$target_host nose2

--- a/ci/script_run_on_non_pull_requests.sh
+++ b/ci/script_run_on_non_pull_requests.sh
@@ -41,6 +41,6 @@ vagrant provision
 # Run selenium tests
 
 # Tell the test running host how to find the biblebox by name
-echo "\n${target_host} biblebox.local" | sudo tee -a /etc/hosts > /dev/null
+echo "\n$(dig +short ${target_host}) biblebox.local" | sudo tee -a /etc/hosts > /dev/null
 cat /etc/hosts
 TEST_IP=$target_host nose2

--- a/ci/tests/test_biblebox_static.py
+++ b/ci/tests/test_biblebox_static.py
@@ -1,26 +1,34 @@
 import os
 import unittest
+import requests
 from selenium import webdriver
 
 TEST_IP_ENV_VAR = "TEST_IP"
 TEST_BASE_URL = "http://biblebox.local"
 
 
+def getTestTarget():
+    try:
+        return os.environ[TEST_IP_ENV_VAR]
+    except KeyError:
+        error_msg = "Set the %s environment variable" % \
+            (TEST_IP_ENV_VAR,)
+        raise RuntimeError(error_msg)
+
+
 class BibleBoxStaticTestCase(unittest.TestCase):
 
-    def getTestTarget(self):
-        try:
-            return os.environ[TEST_IP_ENV_VAR]
-        except KeyError:
-            error_msg = "Set the %s environment variable" % \
-                (TEST_IP_ENV_VAR,)
-            raise RuntimeError(error_msg)
-
     def setUp(self):
-        self.testTarget = self.getTestTarget()
+        self.testTarget = getTestTarget()
         self.browser = webdriver.PhantomJS()
         self.addCleanup(self.browser.quit)
 
     def testPageTitle(self):
         self.browser.get(TEST_BASE_URL)
         self.assertIn("The BibleBox", self.browser.title)
+
+    def testBaseRedirect(self):
+        r = requests.get("http://%s" % (self.testTarget,),
+                         allow_redirects=False)
+        self.assertTrue(r.is_redirect)
+        self.assertEqual(r.headers["Location"], TEST_BASE_URL)

--- a/ci/tests/test_biblebox_static.py
+++ b/ci/tests/test_biblebox_static.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+from selenium import webdriver
+
+TEST_IP_ENV_VAR = "TEST_IP"
+TEST_BASE_URL = "http://biblebox.local"
+
+
+class BibleBoxStaticTestCase(unittest.TestCase):
+
+    def getTestTarget(self):
+        try:
+            return os.environ[TEST_IP_ENV_VAR]
+        except KeyError:
+            error_msg = "Set the %s environment variable" % \
+                (TEST_IP_ENV_VAR,)
+            raise RuntimeError(error_msg)
+
+    def setUp(self):
+        self.testTarget = self.getTestTarget()
+        self.browser = webdriver.PhantomJS()
+        self.addCleanup(self.browser.quit)
+
+    def testPageTitle(self):
+        self.browser.get(TEST_BASE_URL)
+        self.assertIn("The BibleBox", self.browser.title)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ansible==2.1.2.0
 ansible-lint==3.4.3
 nose2==0.6.5
+requests==2.12.1
 selenium==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 ansible==2.1.2.0
 ansible-lint==3.4.3
+nose2==0.6.5
+selenium==3.0.1


### PR DESCRIPTION
Introducing selenium, which will allow us to do automated browser tests during CI.

Initial tests are really about getting the framework in place, but there is a little bit of value for making sure that we redirect when accessing by hostname. Once the interface settles down we can add more tests, including tests for workflows.