### PR TITLE
Parametrise client-facing interface (was wlan0)

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -6,6 +6,10 @@
 #  this file correspond to that group, but then the inventory is
 #  slightly more complex
 
+# Parameterised to allow overriding during CI builds, where we want to
+#  test some client-facing capabilities but do not have a wifi interface
+client_facing_if: "wlan0"
+
 biblebox_default_content_root: /var/www/biblebox/biblebox_default
 biblebox_config_root: /etc/biblebox
 biblebox_usb_files_root: "{{ biblebox_default_content_root }}/shared/usb"
@@ -67,7 +71,7 @@ nginx_default_release: jessie-backports
 
 firewall_v4_group_rules:
   150 redirect http:
-    - -t nat -A PREROUTING -s {{ wlan0_network_cidr }} tcp --dport 80 -j DNAT --to {{ wlan0_ip_address }}:80
+    - -t nat -A PREROUTING -s {{ client_facing_if_network_cidr }} tcp --dport 80 -j DNAT --to {{ client_facing_if_ip_address }}:80
   # Overriding default - we only want ssh on the wired interface
   200 allow ssh:
     - -A INPUT -p tcp -i eth0 --dport ssh -j ACCEPT

--- a/ansible/roles/dns-dhcp/tasks/main.yml
+++ b/ansible/roles/dns-dhcp/tasks/main.yml
@@ -2,8 +2,8 @@
 # Openresolv, by default, wants to update /etc/resolv.conf to use dnsmasq
 #  as a local resolver. We stop it from doing that with resolvconf=NO
 # If 127.0.0.1 is a system resolver when dnsmasq is running, all on-box
-#  queries are answered with the local wlan ip address. This breaks apt
-#  updates and other stuff that needs a working resolver. This means that
+#  queries are answered with the local client-facing ip address. This breaks
+#  apt updates and other stuff that needs a working resolver. This means that
 #  clients get different results to their DNS queries (which are served
 #  from dnsmasq) from queries run on-box i.e. using system resolver
 #

--- a/ansible/roles/dns-dhcp/templates/etc_dnsmasq.conf.j2
+++ b/ansible/roles/dns-dhcp/templates/etc_dnsmasq.conf.j2
@@ -14,7 +14,7 @@ bogus-priv
 no-resolv
 # Return the biblebox-pi address for all queries, unless they match dhcp
 #  leases or are answered from /etc/hosts
-address=/#/{{ wlan0_ip_address }}
+address=/#/{{ client_facing_if_ip_address }}
 
 # Tell clients to cache IP addresses for 5 seconds. This overrides the 
 #  default of 0, which would place more load on this service because 
@@ -30,5 +30,5 @@ quiet-dhcp6
 
 domain={{ hostname }}
 
-interface=wlan0
-dhcp-range={{ dhcp_range_start }},{{ dhcp_range_end }},{{ wlan0_netmask }},{{ dhcp_lease_time }}
+interface={{ client_facing_if }}
+dhcp-range={{ dhcp_range_start }},{{ dhcp_range_end }},{{ client_facing_if_netmask }},{{ dhcp_lease_time }}

--- a/ansible/roles/network-interfaces/defaults/main.yml
+++ b/ansible/roles/network-interfaces/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-wlan0_ip_address: 10.0.0.1
-wlan0_netmask: 255.255.255.0
-wlan0_network_cidr: 10.0.0.0/24
+client_facing_if_ip_address: 10.0.0.1
+client_facing_if_netmask: 255.255.255.0
+client_facing_if_network_cidr: 10.0.0.0/24
 hostname: biblebox.local

--- a/ansible/roles/network-interfaces/templates/etc_network_interfaces.j2
+++ b/ansible/roles/network-interfaces/templates/etc_network_interfaces.j2
@@ -9,8 +9,8 @@ iface lo inet loopback
 
 iface eth0 inet manual
 
-allow-hotplug wlan0
-iface wlan0 inet static
-    address {{ wlan0_ip_address }}
-    netmask {{ wlan0_netmask }}
+allow-hotplug {{ client_facing_if }}
+iface {{ client_facing_if }} inet static
+    address {{ client_facing_if_ip_address }}
+    netmask {{ client_facing_if_netmask }}
     hostapd /etc/hostapd/hostapd.conf


### PR DESCRIPTION
Replace direct references to wlan with references to the client-facing interface. This is a step towards abstracting the client-facing network from the wlan interface so it's easier to test, and easier to drop in a bluetooth PAN as an alternative to wifi, if we go down that path.