### PR TITLE
Remove synchronise module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
   fi
 - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then $TRAVIS_BUILD_DIR/ci/script_run_on_non_pull_requests.sh;
   fi
-- pushd $TRAVIS_BUILD_DIR && ansible-lint -x ANSIBLE0004,ANSIBLE0010,ANSIBLE0012 --exclude=ansible/roles/mikegleasonjr.firewall
+- pushd $TRAVIS_BUILD_DIR && ansible-lint -x ANSIBLE0004,ANSIBLE0006,ANSIBLE0010,ANSIBLE0012 --exclude=ansible/roles/mikegleasonjr.firewall
   --exclude=ansible/roles/geerlingguy.nginx ansible/site.yml && popd
 after_script:
 - pushd $TRAVIS_BUILD_DIR/ci && terraform destroy --force && popd

--- a/ansible/roles/webserver-content/tasks/main.yml
+++ b/ansible/roles/webserver-content/tasks/main.yml
@@ -52,13 +52,13 @@
     - "{{ biblebox_config_root }}"
 
 - name: move default content into place
-  command: rsync -a /tmp/BibleBox-skeleton/content/ {{ biblebox_default_content_root }}
+  command: rsync -a /tmp/BibleBox-skeleton/content {{ biblebox_default_content_root }}
 
-# Trailing slash deliberately absent... we want the shared directory and
-#  it's contents in the target directory.
 - name: move default shared into place
   command: rsync -a /tmp/BibleBox-skeleton/shared {{ biblebox_default_content_root }}
 
+# Trailing slash deliberately present... we want the contents of the config
+#  directory, but not the directory itself in the target.
 - name: move default config into place
   command: rsync -a /tmp/BibleBox-skeleton/config/ {{ biblebox_config_root }}
 

--- a/ansible/roles/webserver-content/tasks/main.yml
+++ b/ansible/roles/webserver-content/tasks/main.yml
@@ -54,8 +54,10 @@
 - name: move default content into place
   command: rsync -a /tmp/BibleBox-skeleton/content/ {{ biblebox_default_content_root }}
 
+# Trailing slash deliberately absent... we want the shared directory and
+#  it's contents in the target directory.
 - name: move default shared into place
-  command: rsync -a /tmp/BibleBox-skeleton/shared/ {{ biblebox_default_content_root }}
+  command: rsync -a /tmp/BibleBox-skeleton/shared {{ biblebox_default_content_root }}
 
 - name: move default config into place
   command: rsync -a /tmp/BibleBox-skeleton/config/ {{ biblebox_config_root }}

--- a/ansible/roles/webserver-content/tasks/main.yml
+++ b/ansible/roles/webserver-content/tasks/main.yml
@@ -52,25 +52,13 @@
     - "{{ biblebox_config_root }}"
 
 - name: move default content into place
-  synchronize:
-      src: /tmp/BibleBox-skeleton/content
-      dest: "{{ biblebox_default_content_root }}"
-      recursive: yes
-  delegate_to: "{{ inventory_hostname }}"
+  command: rsync -a /tmp/BibleBox-skeleton/content/ {{ biblebox_default_content_root }}
 
 - name: move default shared into place
-  synchronize:
-      src: /tmp/BibleBox-skeleton/shared
-      dest: "{{ biblebox_default_content_root }}"
-      recursive: yes
-  delegate_to: "{{ inventory_hostname }}"
+  command: rsync -a /tmp/BibleBox-skeleton/shared/ {{ biblebox_default_content_root }}
 
 - name: move default config into place
-  synchronize:
-      src: /tmp/BibleBox-skeleton/config/
-      dest: "{{ biblebox_config_root }}"
-      recursive: yes
-  delegate_to: "{{ inventory_hostname }}"
+  command: rsync -a /tmp/BibleBox-skeleton/config/ {{ biblebox_config_root }}
 
 # This makes the config files executable but
 # it seems like the only other option is to separately


### PR DESCRIPTION
Fixes problems that occur because the name of the server in the inventory (e.g. `default` for vagrant) isn't the same as the hostname itself. Required whitelisting a lint check.