### PR TITLE
Prepare for Connectbox interface

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -12,7 +12,7 @@ client_facing_if: "wlan0"
 
 biblebox_default_content_root: /var/www/biblebox/biblebox_default
 biblebox_config_root: /etc/biblebox
-biblebox_usb_files_root: "{{ biblebox_default_content_root }}/shared/usb"
+biblebox_usb_files_root: /media/usb0
 biblebox_admin_credentials: admin:$apr1$BBOXFOO2$3rz0Up2HMEfrmGB0YCXzr/
 biblebox_default_hostname: biblebox.local
 
@@ -46,27 +46,15 @@ nginx_vhosts:
         auth_basic_user_file /usr/local/biblebox/etc/basicauth;
       }
 
-      location /shared/ {
+      location /content/ {
         autoindex on;
-        root /media/usb0;
-        try_files $uri $uri/ @sharedfallback;
+        autoindex_format json;
+        charset utf-8;
+        charset_types application/json;
+
+        alias {{ biblebox_usb_files_root }}/;
       }
 
-      location @sharedfallback {
-        autoindex on;
-        root /var/www/biblebox/biblebox_default;
-        try_files $uri $uri/ =404;
-      }
-
-      location / {
-        root /media/usb0/content;
-        try_files $uri $uri/index.html @fallback;
-      }
-
-      location @fallback {
-        root /var/www/biblebox/biblebox_default/content;
-        try_files $uri $uri/ =404;
-      }
 # We want to set the default server. Remove the default server that
 #  nginx provides.
 nginx_remove_default_vhost: true

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -36,7 +36,7 @@ nginx_vhosts:
       # Admin interface
       location /admin/ {
         index index.html;
-        alias {{ biblebox_admin_root }};
+        alias {{ biblebox_admin_root }}/;
         auth_basic "Access Denied";
         auth_basic_user_file /usr/local/biblebox/etc/basicauth;
       }

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -11,6 +11,7 @@
 client_facing_if: "wlan0"
 
 biblebox_default_content_root: /var/www/biblebox/biblebox_default
+biblebox_admin_root: /var/www/biblebox/admin
 biblebox_config_root: /etc/biblebox
 biblebox_usb_files_root: /media/usb0
 biblebox_admin_credentials: admin:$apr1$BBOXFOO2$3rz0Up2HMEfrmGB0YCXzr/
@@ -24,18 +25,26 @@ nginx_vhosts:
     return: "302 http://$hostname"
   - listen: "80"
     server_name: "$hostname"
-    index: "index.php index.htm index.html"
-    root: "/var/www/biblebox"
-    error_page: "404 /biblebox_default/content/index.html"
+    index: "index.html"
+    root: "{{ biblebox_default_content_root }}"
+    error_page: "404 /index.html"
     access_log: "/var/log/nginx/biblebox-access.log"
     error_log: "/var/log/nginx/biblebox-error.log"
     extra_parameters: |
       rewrite_log on;
 
+      # Admin interface
+      location /admin/ {
+        index index.html;
+        alias {{ biblebox_admin_root }};
+        auth_basic "Access Denied";
+        auth_basic_user_file /usr/local/biblebox/etc/basicauth;
+      }
+
+      # Admin worker scripts
       # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
       location ~ ^/admin/(?<script_name>.+\.php)(?<path_info>/.+)$ {
-        index index.html;
-        root /var/www/biblebox/biblebox_default/content;
+        alias {{ biblebox_admin_root }};
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$script_name;
         fastcgi_param PATH_INFO $path_info;

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -10,8 +10,9 @@
 #  test some client-facing capabilities but do not have a wifi interface
 client_facing_if: "wlan0"
 
-biblebox_default_content_root: /var/www/biblebox/biblebox_default
-biblebox_admin_root: /var/www/biblebox/admin
+biblebox_web_root: /var/www/biblebox
+biblebox_default_content_root: "{{ biblebox_web_root }}/biblebox_default"
+biblebox_admin_root: "{{ biblebox_web_root }}/admin"
 biblebox_config_root: /etc/biblebox
 biblebox_usb_files_root: /media/usb0
 biblebox_admin_credentials: admin:$apr1$BBOXFOO2$3rz0Up2HMEfrmGB0YCXzr/
@@ -25,7 +26,7 @@ nginx_vhosts:
     return: "302 http://$hostname"
   - listen: "80"
     server_name: "$hostname"
-    index: "index.html"
+    index: index.html
     root: "{{ biblebox_default_content_root }}"
     error_page: "404 /index.html"
     access_log: "/var/log/nginx/biblebox-access.log"
@@ -35,16 +36,15 @@ nginx_vhosts:
 
       # Admin interface
       location /admin/ {
-        index index.html;
-        alias {{ biblebox_admin_root }}/;
+        root {{ biblebox_web_root }};
         auth_basic "Access Denied";
         auth_basic_user_file /usr/local/biblebox/etc/basicauth;
       }
 
       # Admin worker scripts
-      # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+      # pass the PHP scripts to FastCGI server via unix domain socket
       location ~ ^/admin/(?<script_name>.+\.php)(?<path_info>/.+)$ {
-        alias {{ biblebox_admin_root }};
+        root {{ biblebox_web_root }};
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$script_name;
         fastcgi_param PATH_INFO $path_info;
@@ -56,12 +56,11 @@ nginx_vhosts:
       }
 
       location /content/ {
+        alias {{ biblebox_usb_files_root }}/;
         autoindex on;
         autoindex_format json;
         charset utf-8;
         charset_types application/json;
-
-        alias {{ biblebox_usb_files_root }}/;
       }
 
 # We want to set the default server. Remove the default server that

--- a/ansible/roles/biblebox-pi/meta/main.yml
+++ b/ansible/roles/biblebox-pi/meta/main.yml
@@ -9,4 +9,5 @@ dependencies:
   - mikegleasonjr.firewall
   - webserver-content
   - usb-content
+  - sample-content
   - dns-dhcp

--- a/ansible/roles/sample-content/defaults/main.yml
+++ b/ansible/roles/sample-content/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+#XXX - should be false once we have layout sorted
+deploy_sample_content: true

--- a/ansible/roles/sample-content/tasks/main.yml
+++ b/ansible/roles/sample-content/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- block:
+  - name: Checkout sample content
+    git:
+      repo: https://github.com/edwinsteele/biblebox-sample-content.git
+      dest: /tmp/biblebox-sample-content
+      depth: 1
+
+  - name: Place sample content at USB drive location
+    command: rsync -a /tmp/biblebox-sample-content/content/ {{ biblebox_usb_files_root }}
+
+  when: deploy_sample_content == True

--- a/ansible/roles/usb-content/tasks/main.yml
+++ b/ansible/roles/usb-content/tasks/main.yml
@@ -4,8 +4,8 @@
     name: usbmount
     state: present
 
-- name: Expose usb content to the webserver
-  file:
-    src: /media/usb0
-    dest: "{{ biblebox_usb_files_root }}"
-    state: link
+#- name: Expose usb content to the webserver
+#  file:
+#    src: /media/usb0
+#    dest: "{{ biblebox_usb_files_root }}"
+#    state: link

--- a/ansible/roles/webserver-content/tasks/main.yml
+++ b/ansible/roles/webserver-content/tasks/main.yml
@@ -16,15 +16,6 @@
     enabled: yes
     state: started
 
-# commented force=yes given it blows away anything that's in place
-#  and it's unclear that we actually want that
-- name: checkout biblebox skeleton and deploy as default
-  git:
-    repo: https://github.com/bbriggs/BibleBox-skeleton.git
-    dest: /tmp/BibleBox-skeleton
-    depth: 1
-    #force=yes
-
 - name: create folders for default content/shared and config
   file:
     path: "{{ item }}"
@@ -34,31 +25,6 @@
     mode: 0775
   with_items:
     - "{{ biblebox_default_content_root }}"
-    - "{{ biblebox_config_root }}"
-
-- name: move default content into place
-  command: rsync -a /tmp/BibleBox-skeleton/content {{ biblebox_default_content_root }}
-
-- name: move default shared into place
-  command: rsync -a /tmp/BibleBox-skeleton/shared {{ biblebox_default_content_root }}
-
-# Trailing slash deliberately present... we want the contents of the config
-#  directory, but not the directory itself in the target.
-- name: move default config into place
-  command: rsync -a /tmp/BibleBox-skeleton/config/ {{ biblebox_config_root }}
-
-# This makes the config files executable but
-# it seems like the only other option is to separately
-# set permissions on directory in an additional task
-# Since the config files will probably be going away
-# I think this is fine for now.
-- name: update permissions on biblebox config files
-  file:
-    dest: "{{ biblebox_config_root }}"
-    owner: www-data
-    group: www-data
-    mode: 0755
-    recurse: yes
 
 # Permissions are correctly set in the subsequent task
 - name: Copy biblebox admin ui

--- a/ansible/roles/webserver-content/tasks/main.yml
+++ b/ansible/roles/webserver-content/tasks/main.yml
@@ -35,7 +35,7 @@
     content: |
       <html>
       <head><title>The BibleBox</title></head>
-      <body>Placeholder. <a href="/content">content</a> <a href="/admin">admin</a></body>
+      <body>Placeholder. <a href="/content">content</a> <a href="/admin/">admin</a></body>
       </html>
 
 # Permissions are correctly set in the subsequent task

--- a/ansible/roles/webserver-content/tasks/main.yml
+++ b/ansible/roles/webserver-content/tasks/main.yml
@@ -26,15 +26,27 @@
   with_items:
     - "{{ biblebox_default_content_root }}"
 
+- name: Create placeholder index file
+  copy:
+    dest: "{{ biblebox_default_content_root }}/index.html"
+    owner: www-data
+    group: www-data
+    mode: 0644
+    content: |
+      <html>
+      <head><title>The BibleBox</title></head>
+      <body>Placeholder. <a href="/content">content</a> <a href="/admin">admin</a></body>
+      </html>
+
 # Permissions are correctly set in the subsequent task
 - name: Copy biblebox admin ui
   synchronize:
     src: ../html/
-    dest: "{{ biblebox_default_content_root }}/content/"
+    dest: "{{ biblebox_admin_root }}"
 
 - name: fix ownership of biblebox_default
   file:
-    path: "{{ biblebox_default_content_root }}"
+    path: "{{ biblebox_admin_root }}"
     state: directory
     owner: www-data
     group: www-data

--- a/ansible/roles/webserver-content/tasks/main.yml
+++ b/ansible/roles/webserver-content/tasks/main.yml
@@ -41,7 +41,7 @@
 # Permissions are correctly set in the subsequent task
 - name: Copy biblebox admin ui
   synchronize:
-    src: ../html/
+    src: ../html/admin/
     dest: "{{ biblebox_admin_root }}"
 
 - name: fix ownership of biblebox_default

--- a/tests/test_biblebox_static.py
+++ b/tests/test_biblebox_static.py
@@ -23,6 +23,7 @@ class BibleBoxStaticTestCase(unittest.TestCase):
         self.browser = webdriver.PhantomJS()
         self.addCleanup(self.browser.quit)
 
+    @unittest.skip("Base content page content being redefined")
     def testPageTitle(self):
         self.browser.get(TEST_BASE_URL)
         self.assertIn("The BibleBox", self.browser.title)

--- a/tests/test_biblebox_static.py
+++ b/tests/test_biblebox_static.py
@@ -18,18 +18,30 @@ def getTestTarget():
 
 class BibleBoxStaticTestCase(unittest.TestCase):
 
+    def testBaseRedirect(self):
+        r = requests.get("http://%s" % (getTestTarget(),),
+                         allow_redirects=False)
+        self.assertTrue(r.is_redirect)
+        self.assertEqual(r.headers["Location"], TEST_BASE_URL)
+
+    def testAdminAuthPrompt(self):
+        r = requests.get("%s/admin/" % (TEST_BASE_URL,),
+                         allow_redirects=False)
+        self.assertEquals(r.status_code, 401)
+
+    def testContentResponseType(self):
+        # Content should return json
+        r = requests.get("%s/content/" % (TEST_BASE_URL,))
+        self.assertIsInstance(r.json(), list)
+
+
+class BibleBoxWebDriverTestCase(unittest.TestCase):
+
     def setUp(self):
         self.testTarget = getTestTarget()
         self.browser = webdriver.PhantomJS()
         self.addCleanup(self.browser.quit)
 
-    @unittest.skip("Base content page content being redefined")
     def testPageTitle(self):
         self.browser.get(TEST_BASE_URL)
         self.assertIn("The BibleBox", self.browser.title)
-
-    def testBaseRedirect(self):
-        r = requests.get("http://%s" % (self.testTarget,),
-                         allow_redirects=False)
-        self.assertTrue(r.is_redirect)
-        self.assertEqual(r.headers["Location"], TEST_BASE_URL)


### PR DESCRIPTION
@furnox is going to integrate the client side connect box interface (that was developed at the Boise hack). This prepares for that by:

* Removing the old biblebox interface
* Restructuring the web root to simplify the nginx config
* Exposing the contents of the USB drive as UTF-8 encoded json (per the nginx-autoindex module)
* Adding some sample content so we can see UTF-8 filenames, including arabic so we have a RtL example
