### PR TITLE
Fix broken wifi DNS

### DIFF
--- a/ansible/roles/dns-dhcp/tasks/main.yml
+++ b/ansible/roles/dns-dhcp/tasks/main.yml
@@ -46,6 +46,17 @@
     validate: dnsmasq --test --conf-file=%s
   notify: Reload dnsmasq
 
+# This is necessary because nginx redirects to the hostname, but the hostname
+#  is listed in /etc/hosts and associated with 127.0.0.1 (so dnsmasq uses it
+#  when answering queries). By adding this, and the localise-queries option
+#  to dnsmasq, we answer with the address of the wifi interface. There's no
+#  need to do this for the ethernet interface, as we're not answering queries
+#  on that interface (we're not even listening)
+- name: Add /etc/hosts entry for wifi interface
+  lineinfile:
+    dest: /etc/hosts
+    line: "{{ client_facing_if_ip_address }} {{ biblebox_default_hostname }}"
+
 - name: Start and enable dnsmasq
   service:
     name: dnsmasq

--- a/ansible/roles/dns-dhcp/templates/etc_dnsmasq.conf.j2
+++ b/ansible/roles/dns-dhcp/templates/etc_dnsmasq.conf.j2
@@ -4,20 +4,27 @@
 #  parts, to upstream nameservers. If the name is not known from /etc/hosts
 # or DHCP then a "not found" answer is returned.
 domain-needed
+
 # Bogus private reverse lookups. All reverse lookups for private IP ranges
 #  (ie 192.168.x.x, etc) which are not found in /etc/hosts or the DHCP leases
 #  file are answered with "no such domain" rather than being forwarded
 #  upstream.
 bogus-priv
+
 # Don't read /etc/resolv.conf. Get upstream servers only from the command
 #  line or the dnsmasq configuration file.
 no-resolv
+
 # Return the biblebox-pi address for all queries, unless they match dhcp
 #  leases or are answered from /etc/hosts
 address=/#/{{ client_facing_if_ip_address }}
 
-# Tell clients to cache IP addresses for 5 seconds. This overrides the 
-#  default of 0, which would place more load on this service because 
+# When a host is listed in /etc/hosts with multiple addresses, return the
+#  on associated with the interface on which the query was received.
+localise-queries
+
+# Tell clients to cache IP addresses for 5 seconds. This overrides the
+#  default of 0, which would place more load on this service because
 #  queries would never be cached. By setting the TTL very low, however,
 #  we make sure that the client's resolver won't have the bogus addresses
 #  from this service in cache when it switches away to another WiFi network


### PR DESCRIPTION
Fixed by adding /etc/hosts entry and answering queries with addresses on the querying interface.

Confirmed that tests were failing, and now pass. Our test cases can't catch this in CI yet, as the tests are not yet using the DNS provided by the pi. The move to terraform allows us to setup a second machine in CI and query and get DHCP over a private network, so will ultimately be a part of our test suite.