### PR TITLE
Sample content now lives in the connectbox organisation

### DIFF
--- a/ansible/roles/sample-content/tasks/main.yml
+++ b/ansible/roles/sample-content/tasks/main.yml
@@ -2,7 +2,7 @@
 - block:
   - name: Checkout sample content
     git:
-      repo: https://github.com/edwinsteele/biblebox-sample-content.git
+      repo: https://github.com/ConnectBox/connectbox-sample-content.git
       dest: /tmp/connectbox-sample-content
       depth: 1
 


### PR DESCRIPTION
@furnox @kldavis4 - I’ve moved the sample content repo to the new organisation, so you’ll need to pull in this change to any branches you’re working on if you want the playbook to run successfully.